### PR TITLE
Refactor NumericalData

### DIFF
--- a/src/compas_fd/numdata/__init__.py
+++ b/src/compas_fd/numdata/__init__.py
@@ -1,0 +1,33 @@
+"""
+******************
+compas_fd.numdata
+******************
+
+.. currentmodule:: compas_fd.numdata
+
+
+Classes
+=======
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    NumericalData
+    FDNumericalData
+
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import compas
+from .numerical_data import NumericalData
+
+if not compas.IPY:
+    from .fd_numerical_data import FDNumericalData
+
+__all__ = ['NumericalData']
+
+if not compas.IPY:
+    __all__ += ['FDNumericalData']

--- a/src/compas_fd/numdata/face_data.py
+++ b/src/compas_fd/numdata/face_data.py
@@ -1,0 +1,123 @@
+from numpy import add
+from numpy import cross
+from numpy import roll
+from numpy import zeros
+from numpy.linalg import norm
+from scipy.sparse import coo_matrix
+
+from compas.datastructures import Mesh
+from compas.numerical import face_matrix
+
+
+class FaceDataMixin:
+    """Stores numerical mesh face data.
+    Use as mixin for NumericalData classes.
+    """
+
+    def __init__(self, mesh: Mesh):
+        self.faces_vertices = mesh
+        self.reset_face_data()
+
+    def reset_face_data(self):
+        self._tributary_area_matrix = None
+        self._face_areas = None
+        self._face_normals = None
+        self._face_centroids = None
+        self._face_cross_products = None
+
+    @property
+    def faces_vertices(self):
+        return self._faces_vertices
+
+    @faces_vertices.setter
+    def faces_vertices(self, mesh: Mesh):
+        v_i = mesh.vertex_index()
+        f_i = {fkey: index for index, fkey in enumerate(mesh.faces())}
+        faces_vertices = [None] * mesh.number_of_faces()
+        for f in mesh.faces():
+            faces_vertices[f_i[f]] = [v_i[v] for v in mesh.face_vertices(f)]
+        self._faces_vertices = faces_vertices
+        self._face_matrix = None
+
+    @property
+    def face_matrix(self):
+        if self._face_matrix is None:
+            self._face_matrix = face_matrix(self.faces_vertices, rtype='csr', normalize=True)
+        return self._face_matrix
+
+    @property
+    def tributary_area_matrix(self):
+        """Tributary areas matrix as a sparse (vertices x faces) array.
+        Entry a_ij holds tributary area of face j for vertex i.
+        """
+        if self._tributary_area_matrix is None:
+            self._compute_tributary_area_matrix()
+        return self._tributary_area_matrix
+
+    def _compute_tributary_area_matrix(self):
+        v_count = self.xyz.shape[0]
+        f_count = len(self.faces_vertices)
+        data = []
+        rows = []
+        cols = []
+
+        for face, fcp in enumerate(self.face_cross_products):
+            face_vertices = self.faces_vertices[face]
+            partial_areas = norm(fcp, axis=1)
+            tributary_area = partial_areas + roll(partial_areas, -1)
+            data.extend(tributary_area)
+            rows.extend(face_vertices)
+            cols.extend([face] * len(face_vertices))
+
+        self._tributary_area_matrix = coo_matrix((data, (rows, cols)),
+                                                 (v_count, f_count)).tocsr() * 0.25
+
+    @property
+    def face_areas(self):
+        if self._face_areas is None:
+            self._face_areas = self.tributary_area_matrix.sum(axis=0).reshape((-1, 1))
+        return self._face_areas
+
+    @property
+    def face_normals(self):
+        if self._face_normals is None:
+            self._compute_face_normals()
+        return self._face_normals
+
+    def _compute_face_normals(self):
+        f_count = len(self.faces_vertices)
+        self._face_normals = zeros((f_count, 3), dtype=float)
+        for face, fcp in enumerate(self.face_cross_products):
+            self._face_normals[face, :] = add.reduce(fcp)
+        self._face_normals /= norm(self._face_normals, axis=1)[:, None]
+
+    @property
+    def face_centroids(self):
+        if self._face_centroids is None:
+            self._face_centroids = self.F.dot(self.xyz)
+        return self._face_centroids
+
+    @property
+    def face_cross_products(self):
+        """Cross products of the consecutive (centroid -> vertex)
+        vectors for each of the vertices of the face.
+        """
+        if self._face_cross_products is None:
+            self._compute_face_cross_products()
+        return self._face_cross_products
+
+    def _compute_face_cross_products(self):
+        self._face_cross_products = []
+        centroids = self.face_centroids
+        for face, face_vertices in enumerate(self.faces_vertices):
+            vecs = self.xyz[face_vertices] - centroids[face]
+            vecs_shift = roll(vecs, -1, axis=0)
+            self._face_cross_products.append(cross(vecs, vecs_shift))
+
+    # aliases
+    F = face_matrix
+    TA = tributary_area_matrix
+    fa = face_areas
+    fn = face_normals
+    fc = face_centroids
+    fcp = face_cross_products

--- a/src/compas_fd/numdata/fd_numerical_data.py
+++ b/src/compas_fd/numdata/fd_numerical_data.py
@@ -8,7 +8,6 @@ from typing_extensions import Annotated
 from nptyping import NDArray
 
 from dataclasses import dataclass
-from dataclasses import astuple
 
 from numpy import asarray
 from numpy import float64
@@ -39,9 +38,6 @@ class FDNumericalData(NumericalData):
     residuals: NDArray[(Any, 3), float64] = None
     tangent_residuals: NDArray[(Any, 3), float64] = None
     normal_residuals: NDArray[(Any, 1), float64] = None
-
-    def __iter__(self):
-        return iter(astuple(self))
 
     @classmethod
     def from_params(cls,

--- a/src/compas_fd/numdata/fd_numerical_data.py
+++ b/src/compas_fd/numdata/fd_numerical_data.py
@@ -17,11 +17,12 @@ from scipy.sparse import diags
 
 from compas.numerical import connectivity_matrix
 
-from .result import Result
+from .numerical_data import NumericalData
+from ..result import Result
 
 
 @dataclass
-class FDNumericalData:
+class FDNumericalData(NumericalData):
     """Stores numerical data used by the force density algorithms."""
     free: int
     fixed: int
@@ -48,7 +49,8 @@ class FDNumericalData:
                     fixed: List[int],
                     edges: List[Tuple[int, int]],
                     forcedensities: List[float],
-                    loads: Optional[Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]]] = None):
+                    loads: Optional[Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]]] = None
+                    ):
         """Construct numerical arrays from force density solver input parameters."""
         free = list(set(range(len(vertices))) - set(fixed))
         xyz = asarray(vertices, dtype=float64).reshape((-1, 3))

--- a/src/compas_fd/numdata/fd_numerical_data.py
+++ b/src/compas_fd/numdata/fd_numerical_data.py
@@ -9,12 +9,12 @@ from nptyping import NDArray
 
 from numpy import asarray
 from numpy import float64
-from numpy import normrow
 from numpy import zeros_like
 from scipy.sparse import diags
 
 from compas.datastructures import Mesh
 from compas.numerical import connectivity_matrix
+from compas.numerical import normrow
 
 from compas_fd.result import Result
 from .numerical_data import NumericalData
@@ -23,44 +23,19 @@ from .face_data import FaceDataMixin
 
 class FDNumericalData(FaceDataMixin, NumericalData):
     """Stores numerical data used by the force density algorithms."""
-    free: int
-    fixed: int
-    xyz: NDArray[(Any, 3), float64]
-    C: NDArray[(Any, Any), int]
-    q: NDArray[(Any, 1), float64]
-    Q: NDArray[(Any, Any), float64]
-    p: NDArray[(Any, 1), float64]
-    A: NDArray[(Any, Any), float64]
-    Ai: NDArray[(Any, Any), float64]
-    Af: NDArray[(Any, Any), float64]
-    forces: NDArray[(Any, 1), float64] = None
-    lengths: NDArray[(Any, 1), float64] = None
-    residuals: NDArray[(Any, 3), float64] = None
-    tangent_residuals: NDArray[(Any, 3), float64] = None
-    normal_residuals: NDArray[(Any, 1), float64] = None
 
-    @classmethod
-    def from_params(cls,
-                    vertices: Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]],
-                    fixed: List[int],
-                    edges: List[Tuple[int, int]],
-                    forcedensities: List[float],
-                    loads: Optional[Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]]] = None
-                    ):
-        """Construct numerical arrays from force density solver input parameters."""
-        free = list(set(range(len(vertices))) - set(fixed))
-        xyz = asarray(vertices, dtype=float64).reshape((-1, 3))
-        C = connectivity_matrix(edges, 'csr')
-        Ci = C[:, free]
-        Cf = C[:, fixed]
-        q = asarray(forcedensities, dtype=float64).reshape((-1, 1))
-        Q = diags([q.flatten()], [0])
-        p = (zeros_like(xyz) if loads is None else
-             asarray(loads, dtype=float64).reshape((-1, 3)))
-        A = C.T.dot(Q).dot(C)
-        Ai = Ci.T.dot(Q).dot(Ci)
-        Af = Ci.T.dot(Q).dot(Cf)
-        return cls(free, fixed, xyz, C, q, Q, p, A, Ai, Af)
+    def __init__(self,
+                 vertices: Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]],
+                 fixed: List[int],
+                 edges: List[Tuple[int, int]],
+                 force_densities: List[float],
+                 loads: Optional[Union[Sequence[Annotated[List[float], 3]], NDArray[(Any, 3), float64]]] = None
+                 ):
+        self.xyz = vertices
+        self.fixed = fixed
+        self.edges = edges
+        self.force_densities = force_densities
+        self.loads = loads
 
     @classmethod
     def from_mesh(cls, mesh: Mesh):

--- a/src/compas_fd/numdata/fd_numerical_data.py
+++ b/src/compas_fd/numdata/fd_numerical_data.py
@@ -7,16 +7,16 @@ from typing import Optional
 from typing_extensions import Annotated
 from nptyping import NDArray
 
-from dataclasses import dataclass
-
 from numpy import asarray
 from numpy import float64
+from numpy import normrow
 from numpy import zeros_like
 from scipy.sparse import diags
 
 from compas.datastructures import Mesh
 from compas.numerical import connectivity_matrix
 
+from compas_fd.result import Result
 from .numerical_data import NumericalData
 from .face_data import FaceDataMixin
 

--- a/src/compas_fd/numdata/fd_numerical_data.py
+++ b/src/compas_fd/numdata/fd_numerical_data.py
@@ -14,14 +14,14 @@ from numpy import float64
 from numpy import zeros_like
 from scipy.sparse import diags
 
+from compas.datastructures import Mesh
 from compas.numerical import connectivity_matrix
 
 from .numerical_data import NumericalData
-from ..result import Result
+from .face_data import FaceDataMixin
 
 
-@dataclass
-class FDNumericalData(NumericalData):
+class FDNumericalData(FaceDataMixin, NumericalData):
     """Stores numerical data used by the force density algorithms."""
     free: int
     fixed: int
@@ -63,10 +63,159 @@ class FDNumericalData(NumericalData):
         return cls(free, fixed, xyz, C, q, Q, p, A, Ai, Af)
 
     @classmethod
-    def from_mesh(cls, mesh):
+    def from_mesh(cls, mesh: Mesh):
         """Construct numerical arrays from input mesh."""
-        raise NotImplementedError
+        v_i = mesh.vertex_index()
+        vertices = asarray(mesh.vertices_attributes('xyz'))
+        fixed = [v_i[v] for v in mesh.vertices_where({'is_anchor': True})]
+        edges = [(v_i[u], v_i[v]) for u, v in mesh.edges_where({'_is_edge': True})]
+        force_densities = asarray([attr['q'] for key, attr in
+                                   mesh.edges_where({'_is_edge': True}, True)])
+        loads = asarray(mesh.vertices_attributes(('px', 'py', 'pz')))
+
+        numdata = cls(vertices, fixed, edges, force_densities, loads)
+        super(FDNumericalData, numdata).__init__(mesh)
+        numdata.has_face_data = True
+        return numdata
 
     def to_result(self) -> Result:
         """Parse relevant numerical data into a Result object."""
         return Result(self.xyz, self.residuals, self.forces, self.lengths)
+
+    @property
+    def xyz(self):
+        return self._xyz
+
+    @xyz.setter
+    def xyz(self, vertices):
+        self._xyz = asarray(vertices, dtype=float64).reshape((-1, 3))
+        self.reset_xyz()
+
+    def reset_xyz(self):
+        self._lengths = None
+        self._residuals = None
+        if getattr(self, 'has_face_data', False):
+            FaceDataMixin.reset_face_data(self)
+
+    @property
+    def fixed(self):
+        return self._fixed
+
+    @fixed.setter
+    def fixed(self, fixed):
+        self._fixed = fixed
+        self._free = list(set(range(len(self.xyz))) - set(fixed))
+
+    @property
+    def free(self):
+        return self._free
+
+    @property
+    def edges(self):
+        return self._edges
+
+    @edges.setter
+    def edges(self, edges):
+        self._edges = edges
+        self._connectivity_matrix = None
+        self._connectivity_matrix_free = None
+        self._connectivity_matrix_fixed = None
+
+    @property
+    def connectivity_matrix(self):
+        if self._connectivity_matrix is None:
+            self._connectivity_matrix = connectivity_matrix(self.edges, 'csr')
+        return self._connectivity_matrix
+
+    @property
+    def connectivity_matrix_free(self):
+        if self._connectivity_matrix_free is None:
+            self._connectivity_matrix_free = self.connectivity_matrix[:, self.free]
+        return self._connectivity_matrix_free
+
+    @property
+    def connectivity_matrix_fixed(self):
+        if self._connectivity_matrix_fixed is None:
+            self._connectivity_matrix_fixed = self.connectivity_matrix[:, self.fixed]
+        return self._connectivity_matrix_fixed
+
+    @property
+    def force_densities(self):
+        return self._force_densities
+
+    @force_densities.setter
+    def force_densities(self, force_densities):
+        self._force_densities = asarray(force_densities, dtype=float64).reshape((-1, 1))
+        self._force_densities_matrix = None
+        self._stifness_matrix = None
+        self._stifness_matrix_free = None
+        self._stifness_matrix_fixed = None
+        self._forces = None
+        self._residuals = None
+
+    @property
+    def force_densities_matrix(self):
+        if self._force_densities_matrix is None:
+            self._force_densities_matrix = diags(
+                [self.force_densities.flatten()], [0])
+        return self._force_densities_matrix
+
+    @property
+    def loads(self):
+        return self._loads
+
+    @loads.setter
+    def loads(self, loads):
+        self._loads = (zeros_like(self.xyz) if loads is None else
+                       asarray(loads, dtype=float64).reshape((-1, 3)))
+        self._residuals = None
+
+    @property
+    def stifness_matrix(self):
+        if self._stifness_matrix is None:
+            self._stifness_matrix = self.C.T.dot(self.Q).dot(self.C)
+        return self._stifness_matrix
+
+    @property
+    def stifness_matrix_free(self):
+        if self._stifness_matrix_free is None:
+            self._stifness_matrix_free = self.Ci.T.dot(self.Q).dot(self.Ci)
+        return self._stifness_matrix_free
+
+    @property
+    def stifness_matrix_fixed(self):
+        if self._stifness_matrix_fixed is None:
+            self._stifness_matrix_fixed = self.Ci.T.dot(self.Q).dot(self.Cf)
+        return self._stifness_matrix_fixed
+
+    @property
+    def forces(self):
+        if self._forces is None:
+            self._forces = self.q * self.ls
+        return self._forces
+
+    @property
+    def lengths(self):
+        if self._lengths is None:
+            self._lengths = normrow(self.C.dot(self.xyz))
+        return self._lengths
+
+    @property
+    def residuals(self):
+        if self._residuals is None:
+            self._residuals = self.p - self.D.dot(self.xyz)
+        return self._residuals
+
+    # aliases
+    C = connectivity_matrix
+    Ci = connectivity_matrix_free
+    Cf = connectivity_matrix_fixed
+    q = force_densities
+    Q = force_densities_matrix
+    p = loads
+    D = stifness_matrix
+    Di = stifness_matrix_free
+    Df = stifness_matrix_fixed
+    f = forces
+    ls = lengths
+    r = residuals

--- a/src/compas_fd/numdata/numerical_data.py
+++ b/src/compas_fd/numdata/numerical_data.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from dataclasses import astuple
+
+from ..result import Result
+
+
+@dataclass
+class NumericalData:
+    """Storage class for numerical arrays used by solver algorithms."""
+
+    def __iter__(self):
+        return iter(astuple(self))
+
+    @classmethod
+    def from_params(cls, *args, **kwargs):
+        """Construct nuerical arrays from algorithm input parameters."""
+        raise NotImplementedError
+
+    @classmethod
+    def from_mesh(cls, mesh):
+        """Construct numerical arrays from input mesh."""
+        raise NotImplementedError
+
+    def to_result(self) -> Result:
+        """Parse relevant numerical data into a Result object."""
+        raise NotImplementedError


### PR DESCRIPTION
Change FDNumericalData from dataclass into regular class with lazy calculation of property variables.
Implicit recalculation of  dependent variables. Add shorthand aliases to numerical arrays.

Add FaceData mixin for NumericalData.
Its responsibility is to keep track of all numerical mesh face arrays, and lazily compute them on demand.
Its arrays can be used for general purposes: face load computation, face stresses, Natural Force Density solver, ...
